### PR TITLE
Updated the indexer to use latest ngraph modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+node_modules

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/layout.js
+++ b/layout.js
@@ -1,18 +1,17 @@
-require('./loadGraph.js')(runLayout);
+var loadGraph = require('./lib/loadGraph.js');
+var graph = loadGraph();
 
-function runLayout(graph) {
-  console.log('Loaded graph with ' + graph.getLinksCount() + ' edges; ' + graph.getNodesCount() + ' nodes');
+console.log('Loaded graph with ' + graph.getLinksCount() + ' edges; ' + graph.getNodesCount() + ' nodes');
 
-  var layout = require('ngraph.offline.layout')(graph);
+var layout = require('ngraph.offline.layout')(graph);
 
-  console.log('Starting layout');
-  layout.run();
+console.log('Starting layout');
+layout.run();
 
-  var save = require('ngraph.tobinary');
-  save(graph, {
-    outDir: './data'
-  });
+var save = require('ngraph.tobinary');
+save(graph, {
+  outDir: './data'
+});
 
-  console.log('Done.');
-  console.log('Copy `links.bin`, `labels.bin` and positions.bin into vis folder');
-}
+console.log('Done.');
+console.log('Copy `links.bin`, `labels.bin` and positions.bin into vis folder');

--- a/lib/loadGraph.js
+++ b/lib/loadGraph.js
@@ -4,8 +4,8 @@ var dot = require('ngraph.fromdot');
 
 module.exports = loadGraph;
 
-function loadGraph(doneCallback, fileName) {
-  fileName = fileName || process.argv[2] || path.join('data', 'packages');
+function loadGraph(fileName) {
+  fileName = fileName || process.argv[2] || path.join('data', 'fedora.dot');
   if (!fs.existsSync(fileName)) {
     throw new Error('Make sure to download packages first with `download.sh`')
   }
@@ -13,7 +13,5 @@ function loadGraph(doneCallback, fileName) {
   graphStr = fs.readFileSync(fileName, 'utf-8');
 
   console.log("Parsing with dot ...");
-
-  doneCallback(dot(graphStr));
-  return;
+  return dot(graphStr);
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/shaded-enmity/allfedora"
   },
   "dependencies": {
-    "ngraph.graph": "0.0.11",
+    "ngraph.graph": "0.0.12",
     "ngraph.fromdot": "0.1.5",
-    "ngraph.offline.layout": "^1.0.0",
+    "ngraph.offline.layout": "^1.0.1",
     "ngraph.tobinary": "^1.0.1"
   }
 }


### PR DESCRIPTION
This should let you build the graph for the fedora packages:

![image](https://cloud.githubusercontent.com/assets/225407/10261572/5967bf54-6953-11e5-8ffe-15b7f5d83fda.png)

Update the npm dependencies:

```
rm -rf ./node_modules
npm i
```

Then run `node layout.js`. This script currently assumes there is a `fedora.dot` file in the `data` folder. Not sure if this is accurate assumption.

Finally, I restructured code a little bit to match other "all..." packages
family.
