### PR TITLE
Updated to the latest dot parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "ngraph.graph": "0.0.12",
-    "ngraph.fromdot": "0.1.5",
+    "ngraph.fromdot": "0.1.6",
     "ngraph.offline.layout": "^1.0.1",
     "ngraph.tobinary": "^1.0.1"
   }


### PR DESCRIPTION
This should fix a potential problem if a dot file generating tool was
using anonymous subgraphs (for example gvpack does that).

Latest ngraph.fromdot should handle these graphs properly.
